### PR TITLE
Workflow only runs on push, not pr

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -3,7 +3,7 @@
 
 name: Node.js CI
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   build:


### PR DESCRIPTION
Stops workflow from running on PR creation, when has already run for each push.