### PR TITLE
Only run tests on Node 14

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,7 +12,8 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [13.x, 14.x, 15.x]
+        # node-version: [13.x, 14.x, 15.x]
+        node-version: [14.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
## Background
- Github actions compute time is limited to 2k mins/month so no need to waste it all

## Changes
- restricts workflow to only run on node 14